### PR TITLE
Feature/cell registration

### DIFF
--- a/SKTableViewDataSource.xcodeproj/project.pbxproj
+++ b/SKTableViewDataSource.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		1431B8981EEB095700D767DA /* MockTableViewDataSourceDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1431B8901EEB094A00D767DA /* MockTableViewDataSourceDelegate.swift */; };
 		1431B8991EEB095700D767DA /* TableViewDataSourceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1431B8911EEB094A00D767DA /* TableViewDataSourceSpec.swift */; };
 		146437631EEB045B008FD84F /* SKTableViewDataSource.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 146437591EEB045B008FD84F /* SKTableViewDataSource.framework */; };
+		14810B7F1EF1BA98005F537B /* MockTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14810B7D1EF1B9EE005F537B /* MockTableView.swift */; };
 		96FF1F5635B01DE193BFD4EC /* Pods_SKTableViewDataSourceTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 17E39F37AA983FEBB68D3340 /* Pods_SKTableViewDataSourceTests.framework */; };
 		A4037CCAF6A616EF41FEEC5A /* Pods_SKTableViewDataSource.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BA505166F294676FA42C2521 /* Pods_SKTableViewDataSource.framework */; };
 /* End PBXBuildFile section */
@@ -37,6 +38,7 @@
 		1431B8911EEB094A00D767DA /* TableViewDataSourceSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewDataSourceSpec.swift; sourceTree = "<group>"; };
 		146437591EEB045B008FD84F /* SKTableViewDataSource.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SKTableViewDataSource.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		146437621EEB045B008FD84F /* SKTableViewDataSourceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SKTableViewDataSourceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		14810B7D1EF1B9EE005F537B /* MockTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockTableView.swift; sourceTree = "<group>"; };
 		17E39F37AA983FEBB68D3340 /* Pods_SKTableViewDataSourceTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SKTableViewDataSourceTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3EA611E15AC3B313A20CFCDD /* Pods-SKTableViewDataSourceTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SKTableViewDataSourceTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-SKTableViewDataSourceTests/Pods-SKTableViewDataSourceTests.release.xcconfig"; sourceTree = "<group>"; };
 		85950265CD0523A847FF3446 /* Pods-SKTableViewDataSource.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SKTableViewDataSource.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SKTableViewDataSource/Pods-SKTableViewDataSource.debug.xcconfig"; sourceTree = "<group>"; };
@@ -78,6 +80,7 @@
 			isa = PBXGroup;
 			children = (
 				1431B88F1EEB094A00D767DA /* Info.plist */,
+				14810B7D1EF1B9EE005F537B /* MockTableView.swift */,
 				1431B8901EEB094A00D767DA /* MockTableViewDataSourceDelegate.swift */,
 				1431B8911EEB094A00D767DA /* TableViewDataSourceSpec.swift */,
 			);
@@ -343,6 +346,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1431B8981EEB095700D767DA /* MockTableViewDataSourceDelegate.swift in Sources */,
+				14810B7F1EF1BA98005F537B /* MockTableView.swift in Sources */,
 				1431B8991EEB095700D767DA /* TableViewDataSourceSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SKTableViewDataSource.xcodeproj/xcshareddata/xcschemes/SKTableViewDataSource.xcscheme
+++ b/SKTableViewDataSource.xcodeproj/xcshareddata/xcschemes/SKTableViewDataSource.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/SampleProject/SampleProject.xcodeproj/project.pbxproj
+++ b/SampleProject/SampleProject.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1431B89B1EEB0A6700D767DA /* SKTableViewDataSource.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1431B89A1EEB0A6700D767DA /* SKTableViewDataSource.framework */; };
-		1431B89C1EEB0A6700D767DA /* SKTableViewDataSource.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1431B89A1EEB0A6700D767DA /* SKTableViewDataSource.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		14810B781EF18B89005F537B /* SKTableViewDataSource.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14810B751EF18B7E005F537B /* SKTableViewDataSource.framework */; };
+		14810B791EF18B89005F537B /* SKTableViewDataSource.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 14810B751EF18B7E005F537B /* SKTableViewDataSource.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		14D916141EE5107B002D0ABA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D916011EE5107B002D0ABA /* AppDelegate.swift */; };
 		14D916151EE5107B002D0ABA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 14D916021EE5107B002D0ABA /* Assets.xcassets */; };
 		14D916181EE5107B002D0ABA /* EditableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D916071EE5107B002D0ABA /* EditableViewController.swift */; };
@@ -22,19 +22,26 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		146437801EEB04AC008FD84F /* PBXContainerItemProxy */ = {
+		14810B741EF18B7E005F537B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 1464377B1EEB04AC008FD84F /* SKTableViewDataSource.xcodeproj */;
+			containerPortal = 14810B6F1EF18B7E005F537B /* SKTableViewDataSource.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 146437591EEB045B008FD84F;
 			remoteInfo = SKTableViewDataSource;
 		};
-		146437821EEB04AC008FD84F /* PBXContainerItemProxy */ = {
+		14810B761EF18B7E005F537B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 1464377B1EEB04AC008FD84F /* SKTableViewDataSource.xcodeproj */;
+			containerPortal = 14810B6F1EF18B7E005F537B /* SKTableViewDataSource.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 146437621EEB045B008FD84F;
 			remoteInfo = SKTableViewDataSourceTests;
+		};
+		14810B7A1EF18B89005F537B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 14810B6F1EF18B7E005F537B /* SKTableViewDataSource.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 146437581EEB045B008FD84F;
+			remoteInfo = SKTableViewDataSource;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -45,7 +52,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				1431B89C1EEB0A6700D767DA /* SKTableViewDataSource.framework in Embed Frameworks */,
+				14810B791EF18B89005F537B /* SKTableViewDataSource.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -53,8 +60,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		1431B89A1EEB0A6700D767DA /* SKTableViewDataSource.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = SKTableViewDataSource.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		1464377B1EEB04AC008FD84F /* SKTableViewDataSource.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = SKTableViewDataSource.xcodeproj; sourceTree = "<group>"; };
+		14810B6F1EF18B7E005F537B /* SKTableViewDataSource.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SKTableViewDataSource.xcodeproj; path = ../SKTableViewDataSource.xcodeproj; sourceTree = "<group>"; };
 		14D916011EE5107B002D0ABA /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		14D916021EE5107B002D0ABA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		14D916031EE5107B002D0ABA /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -74,18 +80,18 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1431B89B1EEB0A6700D767DA /* SKTableViewDataSource.framework in Frameworks */,
+				14810B781EF18B89005F537B /* SKTableViewDataSource.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		1464377C1EEB04AC008FD84F /* Products */ = {
+		14810B701EF18B7E005F537B /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				146437811EEB04AC008FD84F /* SKTableViewDataSource.framework */,
-				146437831EEB04AC008FD84F /* SKTableViewDataSourceTests.xctest */,
+				14810B751EF18B7E005F537B /* SKTableViewDataSource.framework */,
+				14810B771EF18B7E005F537B /* SKTableViewDataSourceTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -127,10 +133,9 @@
 		C513798D1E8DBCE500E1BB01 = {
 			isa = PBXGroup;
 			children = (
-				1431B89A1EEB0A6700D767DA /* SKTableViewDataSource.framework */,
 				14D915FF1EE5107B002D0ABA /* SampleProject */,
 				C51379971E8DBCE500E1BB01 /* Products */,
-				1464377B1EEB04AC008FD84F /* SKTableViewDataSource.xcodeproj */,
+				14810B6F1EF18B7E005F537B /* SKTableViewDataSource.xcodeproj */,
 			);
 			sourceTree = "<group>";
 		};
@@ -157,6 +162,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				14810B7B1EF18B89005F537B /* PBXTargetDependency */,
 			);
 			name = SampleProject;
 			productName = TableViewDataSource;
@@ -193,8 +199,8 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProductGroup = 1464377C1EEB04AC008FD84F /* Products */;
-					ProjectRef = 1464377B1EEB04AC008FD84F /* SKTableViewDataSource.xcodeproj */;
+					ProductGroup = 14810B701EF18B7E005F537B /* Products */;
+					ProjectRef = 14810B6F1EF18B7E005F537B /* SKTableViewDataSource.xcodeproj */;
 				},
 			);
 			projectRoot = "";
@@ -205,18 +211,18 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		146437811EEB04AC008FD84F /* SKTableViewDataSource.framework */ = {
+		14810B751EF18B7E005F537B /* SKTableViewDataSource.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = SKTableViewDataSource.framework;
-			remoteRef = 146437801EEB04AC008FD84F /* PBXContainerItemProxy */;
+			remoteRef = 14810B741EF18B7E005F537B /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		146437831EEB04AC008FD84F /* SKTableViewDataSourceTests.xctest */ = {
+		14810B771EF18B7E005F537B /* SKTableViewDataSourceTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
 			path = SKTableViewDataSourceTests.xctest;
-			remoteRef = 146437821EEB04AC008FD84F /* PBXContainerItemProxy */;
+			remoteRef = 14810B761EF18B7E005F537B /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -250,6 +256,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		14810B7B1EF18B89005F537B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SKTableViewDataSource;
+			targetProxy = 14810B7A1EF18B89005F537B /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		C51379B11E8DBCE500E1BB01 /* Debug */ = {

--- a/SampleProject/SampleProject/ViewControllers/EditableViewController.swift
+++ b/SampleProject/SampleProject/ViewControllers/EditableViewController.swift
@@ -22,11 +22,9 @@ class EditableViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let reuseId = "SingleSectionViewControllerReuseId"
-        tableView.register(UITableViewCell.self, forCellReuseIdentifier: reuseId)
-
         let array = ["Alaska", "Alabama", "Arkansas", "American Samoa", "Arizona", "California", "Colorado", "Connecticut", "District of Columbia", "Delaware", "Florida", "Georgia", "Guam", "Hawaii", "Iowa", "Idaho", "Illinois", "Indiana", "Kansas", "Kentucky", "Louisiana", "Massachusetts", "Maryland", "Maine", "Michigan", "Minnesota", "Missouri", "Mississippi", "Montana", "North Carolina", "North Dakota", "Nebraska", "New Hampshire", "New Jersey", "New Mexico", "Nevada", "New York", "Ohio", "Oklahoma", "Oregon", "Pennsylvania", "Puerto Rico", "Rhode Island", "South Carolina", "South Dakota", "Tennessee", "Texas", "Utah", "Virginia", "Virgin Islands", "Vermont", "Washington", "Wisconsin", "West Virginia", "Wyoming"]
-        dataSource = TableViewDataSource(objects: array, cellReuseId: reuseId, cellPresenter: { (cell, object) in
+
+        dataSource = TableViewDataSource(objects: array, cell: UITableViewCell.self, cellPresenter: { (cell, object) in
             cell.textLabel?.text = object
         })
 

--- a/SampleProject/SampleProject/ViewControllers/HomeViewController.swift
+++ b/SampleProject/SampleProject/ViewControllers/HomeViewController.swift
@@ -24,17 +24,13 @@ class HomeViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let reuseId = "HomeViewControllerReuseId"
-
-        tableView.register(UITableViewCell.self, forCellReuseIdentifier: reuseId)
-
         let array: [Rows] = [
             .singleSection,
             .multiSection,
             .editable,
         ]
 
-        dataSource = TableViewDataSource(objects: array, cellReuseId: reuseId, cellPresenter: { (cell, object) in
+        dataSource = TableViewDataSource(objects: array, cell: UITableViewCell.self, cellPresenter: { (cell, object) in
             cell.textLabel?.text = object.rawValue
         })
 

--- a/SampleProject/SampleProject/ViewControllers/MultiSectionViewController.swift
+++ b/SampleProject/SampleProject/ViewControllers/MultiSectionViewController.swift
@@ -18,9 +18,6 @@ class MultiSectionViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let reuseId = "MultiSectionViewControllerReuseId"
-        tableView.register(UITableViewCell.self, forCellReuseIdentifier: reuseId)
-
         let array = [["Alaska", "Alabama", "Arkansas", "American Samoa", "Arizona"], ["California", "Colorado", "Connecticut"], ["District of Columbia", "Delaware"], ["Florida"], ["Georgia", "Guam"], ["Hawaii"], ["Iowa", "Idaho", "Illinois", "Indiana"], ["Kansas", "Kentucky"], ["Louisiana"], ["Massachusetts", "Maryland", "Maine", "Michigan", "Minnesota", "Missouri", "Mississippi", "Montana"], ["North Carolina", "North Dakota", "Nebraska", "New Hampshire", "New Jersey", "New Mexico", "Nevada", "New York"], ["Ohio", "Oklahoma", "Oregon"], ["Pennsylvania", "Puerto Rico"], ["Rhode Island"], ["South Carolina", "South Dakota"], ["Tennessee", "Texas"], ["Utah"], ["Virginia", "Virgin Islands", "Vermont"], ["Washington", "Wisconsin", "West Virginia", "Wyoming"]]
 
         var headerTitles = [String]()
@@ -34,7 +31,7 @@ class MultiSectionViewController: UIViewController {
             headerTitles.append(firstLetter)
         }
 
-        dataSource = TableViewDataSource(objects: array, cellReuseId: reuseId, cellPresenter: { (cell, object) in
+        dataSource = TableViewDataSource(objects: array, cell: UITableViewCell.self, cellPresenter: { (cell, object) in
             cell.textLabel?.text = object
         })
 

--- a/SampleProject/SampleProject/ViewControllers/SingleSectionViewController.swift
+++ b/SampleProject/SampleProject/ViewControllers/SingleSectionViewController.swift
@@ -18,14 +18,12 @@ class SingleSectionViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let reuseId = "SingleSectionViewControllerReuseId"
-        tableView.register(UITableViewCell.self, forCellReuseIdentifier: reuseId)
-
         let array = ["Alaska", "Alabama", "Arkansas", "American Samoa", "Arizona", "California", "Colorado", "Connecticut", "District of Columbia", "Delaware", "Florida", "Georgia", "Guam", "Hawaii", "Iowa", "Idaho", "Illinois", "Indiana", "Kansas", "Kentucky", "Louisiana", "Massachusetts", "Maryland", "Maine", "Michigan", "Minnesota", "Missouri", "Mississippi", "Montana", "North Carolina", "North Dakota", "Nebraska", "New Hampshire", "New Jersey", "New Mexico", "Nevada", "New York", "Ohio", "Oklahoma", "Oregon", "Pennsylvania", "Puerto Rico", "Rhode Island", "South Carolina", "South Dakota", "Tennessee", "Texas", "Utah", "Virginia", "Virgin Islands", "Vermont", "Washington", "Wisconsin", "West Virginia", "Wyoming"]
 
-        dataSource = TableViewDataSource(objects: array, cellReuseId: reuseId, cellPresenter: { (cell, object) in
+        dataSource = TableViewDataSource(objects: array, cell: UITableViewCell.self, cellPresenter: { (cell, object) in
             cell.textLabel?.text = object
         })
+
         tableView.dataSource = dataSource
     }
 }

--- a/Source/TableViewDataSource.swift
+++ b/Source/TableViewDataSource.swift
@@ -78,38 +78,74 @@ public class TableViewDataSource<T>: NSObject, UITableViewDataSource {
 
     // MARK: Initializers
 
-    // TODO: Document
-    public convenience init(objects: [T]?, cellPresenter: CellPresenter? = nil) {
+    /// Initializes a data source object. Note, using this initializer requires the delegate
+    /// to always return a cell through the cellForRowAtIndex method.
+    ///
+    /// - Parameters:
+    ///   - objects: The objects to be displayed in the table view.
+    ///   - cellPresenter: An optional closure that can be used to inject view styling and further configuration.
+    ///   - delegate: The object acting as the delegate to the data source.
+    public convenience init(objects: [T]?, cellPresenter: CellPresenter? = nil, delegate: TableViewDataSourceDelegate) {
         let wrappedObjects = TableViewDataSource.wrapObjects(objects)
 
         self.init(objects: wrappedObjects, cellClass: nil, cellNib: nil, cellPresenter: cellPresenter)
+
+        self.delegate = delegate
     }
 
-    // TODO: Document
-    public convenience init(objects: [[T]]?, cellPresenter: CellPresenter? = nil) {
+    /// Initializes a data source object. Note, using this initializer requires the delegate
+    /// to always return a cell through the cellForRowAtIndex method.
+    ///
+    /// - Parameters:
+    ///   - objects: The objects to be displayed in the table view.
+    ///   - cellPresenter: An optional closure that can be used to inject view styling and further configuration.
+    ///   - delegate: The object acting as the delegate to the data source.
+    public convenience init(objects: [[T]]?, cellPresenter: CellPresenter? = nil, delegate: TableViewDataSourceDelegate) {
         self.init(objects: objects, cellClass: nil, cellNib: nil, cellPresenter: cellPresenter)
+
+        self.delegate = delegate
     }
 
-    // TODO: Document
+    /// Initializes a data source object.
+    ///
+    /// - Parameters:
+    ///   - objects: The objects to be displayed in the table view.
+    ///   - cell: The nib of the cell to display in the table view.
+    ///   - cellPresenter: An optional closure that can be used to inject view styling and further configuration.
     public convenience init(objects: [T]?, cell: UINib, cellPresenter: CellPresenter? = nil) {
         let wrappedObjects = TableViewDataSource.wrapObjects(objects)
 
         self.init(objects: wrappedObjects, cell: cell, cellPresenter: cellPresenter)
     }
 
-    // TODO: Document
+    /// Initializes a data source object.
+    ///
+    /// - Parameters:
+    ///   - objects: The objects to be displayed in the table view.
+    ///   - cell: The nib of the cell to display in the table view.
+    ///   - cellPresenter: An optional closure that can be used to inject view styling and further configuration.
     public convenience init(objects: [[T]]?, cell: UINib, cellPresenter: CellPresenter? = nil) {
         self.init(objects: objects, cellNib: cell, cellPresenter: cellPresenter)
     }
 
-    // TODO: Document
+    /// Initializes a data source object.
+    ///
+    /// - Parameters:
+    ///   - objects: The objects to be displayed in the table view.
+    ///   - cell: The class of the cell to display in the table view.
+    ///   - cellPresenter: An optional closure that can be used to inject view styling and further configuration.
     public convenience init(objects: [T]?, cell: UITableViewCell.Type, cellPresenter: CellPresenter? = nil) {
         let wrappedObjects = TableViewDataSource.wrapObjects(objects)
 
         self.init(objects: wrappedObjects, cellClass: cell, cellPresenter: cellPresenter)
     }
 
-    // TODO: Document
+    /// Initializes a data source object.
+    ///
+    /// - Parameters:
+    ///   - objects: The objects to be displayed in the table view.
+    ///   - cell: The class of the cell to display in the table view.
+    ///   - cellPresenter: An optional closure that can be used to inject view styling and further configuration.
     public convenience init(objects: [[T]]?, cell: UITableViewCell.Type, cellPresenter: CellPresenter? = nil) {
         self.init(objects: objects, cellClass: cell, cellPresenter: cellPresenter)
     }

--- a/Source/TableViewDataSource.swift
+++ b/Source/TableViewDataSource.swift
@@ -82,12 +82,12 @@ public class TableViewDataSource<T>: NSObject, UITableViewDataSource {
     public convenience init(objects: [T]?, cellPresenter: CellPresenter? = nil) {
         let wrappedObjects = TableViewDataSource.wrapObjects(objects)
 
-        self.init(objects: wrappedObjects, cellPresenter: cellPresenter)
+        self.init(objects: wrappedObjects, cellClass: nil, cellNib: nil, cellPresenter: cellPresenter)
     }
 
     // TODO: Document
     public convenience init(objects: [[T]]?, cellPresenter: CellPresenter? = nil) {
-        self.init(objects: objects, cellPresenter: cellPresenter)
+        self.init(objects: objects, cellClass: nil, cellNib: nil, cellPresenter: cellPresenter)
     }
 
     // TODO: Document

--- a/Source/TableViewDataSource.swift
+++ b/Source/TableViewDataSource.swift
@@ -83,9 +83,9 @@ public class TableViewDataSource<T>: NSObject, UITableViewDataSource {
     ///
     /// - Parameters:
     ///   - objects: The objects to be displayed in the table view.
-    ///   - cellPresenter: An optional closure that can be used to inject view styling and further configuration.
     ///   - delegate: The object acting as the delegate to the data source.
-    public convenience init(objects: [T]?, cellPresenter: CellPresenter? = nil, delegate: TableViewDataSourceDelegate) {
+    ///   - cellPresenter: An optional closure that can be used to inject view styling and further configuration.
+    public convenience init(objects: [T]?, delegate: TableViewDataSourceDelegate, cellPresenter: CellPresenter? = nil) {
         let wrappedObjects = TableViewDataSource.wrapObjects(objects)
 
         self.init(objects: wrappedObjects, cellClass: nil, cellNib: nil, cellPresenter: cellPresenter)
@@ -98,9 +98,9 @@ public class TableViewDataSource<T>: NSObject, UITableViewDataSource {
     ///
     /// - Parameters:
     ///   - objects: The objects to be displayed in the table view.
-    ///   - cellPresenter: An optional closure that can be used to inject view styling and further configuration.
     ///   - delegate: The object acting as the delegate to the data source.
-    public convenience init(objects: [[T]]?, cellPresenter: CellPresenter? = nil, delegate: TableViewDataSourceDelegate) {
+    ///   - cellPresenter: An optional closure that can be used to inject view styling and further configuration.
+    public convenience init(objects: [[T]]?, delegate: TableViewDataSourceDelegate, cellPresenter: CellPresenter? = nil) {
         self.init(objects: objects, cellClass: nil, cellNib: nil, cellPresenter: cellPresenter)
 
         self.delegate = delegate

--- a/Source/TableViewDataSource.swift
+++ b/Source/TableViewDataSource.swift
@@ -68,13 +68,13 @@ public class TableViewDataSource<T>: NSObject, UITableViewDataSource {
 
     let cellClass: UITableViewCell.Type?
 
+    var reuseId: String?
+
     // MARK: Private variables
 
     fileprivate let cellPresenter: CellPresenter?
 
     fileprivate(set) var objects: [[T]]
-
-    fileprivate var reuseId: String?
 
     // MARK: Initializers
 
@@ -219,9 +219,9 @@ public class TableViewDataSource<T>: NSObject, UITableViewDataSource {
         self.objects = objects ?? [[T]]()
     }
 
-    // MARK: Private Methods
+    // MARK: Internal Methods
 
-    private func registerCellIfNeeded(tableView: UITableView) -> String {
+    func registerCellIfNeeded(tableView: UITableView) -> String {
         if let reuseId = reuseId {
             return reuseId
         }
@@ -233,7 +233,8 @@ public class TableViewDataSource<T>: NSObject, UITableViewDataSource {
         } else if let cellClass = cellClass {
             tableView.register(cellClass, forCellReuseIdentifier: generatedReuseId)
         } else {
-            assertionFailure("A cell could not be registered because a nib or class was not provided and the TableViewDataSource delegate cellForRowAtIndexPath method did not return a cell. Provide a nib, class, or cell from the delegate method.")
+            let exception = NSException(name: .internalInconsistencyException, reason: "A cell could not be registered because a nib or class was not provided and the TableViewDataSource delegate cellForRowAtIndexPath method did not return a cell. Provide a nib, class, or cell from the delegate method.", userInfo: nil)
+            exception.raise()
         }
 
         self.reuseId = generatedReuseId
@@ -241,17 +242,21 @@ public class TableViewDataSource<T>: NSObject, UITableViewDataSource {
         return generatedReuseId
     }
 
-    private func sectionArray(_ indexPath: IndexPath) -> [T] {
-        return objects[indexPath.section]
-    }
+    // MARK: Internal Static Methods
 
-    private static func wrapObjects(_ objects: [T]?) -> [[T]] {
+    static func wrapObjects(_ objects: [T]?) -> [[T]] {
         var wrappedObjects: [[T]]? = nil
         if let objects = objects {
             wrappedObjects = [objects]
         }
 
         return wrappedObjects ?? [[T]]()
+    }
+
+    // MARK: Private Methods
+
+    private func sectionArray(_ indexPath: IndexPath) -> [T] {
+        return objects[indexPath.section]
     }
 
     // MARK: UITableViewDataSource Methods

--- a/Tests/MockTableView.swift
+++ b/Tests/MockTableView.swift
@@ -1,0 +1,23 @@
+//
+//  MockTableView.swift
+//  SKTableViewDataSource
+//
+//  Created by Sean on 6/14/17.
+//  Copyright © 2017 Sean Kladek. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+class MockTableView: UITableView {
+    var registerClassCaled = false
+    var registerNibCalled = false
+
+    override func register(_ cellClass: AnyClass?, forCellReuseIdentifier identifier: String) {
+        registerClassCaled = true
+    }
+
+    override func register(_ nib: UINib?, forCellReuseIdentifier identifier: String) {
+        registerNibCalled = true
+    }
+}

--- a/Tests/TableViewDataSourceSpec.swift
+++ b/Tests/TableViewDataSourceSpec.swift
@@ -23,7 +23,7 @@ class TableViewDataSourceSpec: QuickSpec {
                 let objects = ["One", "Two", "Three"]
 
                 beforeEach() {
-                    self.unitUnderTest = TableViewDataSource(objects: objects, cellReuseId: self.reuseId)
+                    self.unitUnderTest = TableViewDataSource(objects: objects)
                 }
 
                 it("Should wrap the objects array in an array and set to objects") {
@@ -35,7 +35,7 @@ class TableViewDataSourceSpec: QuickSpec {
                 let objects: [[String]] = [["One", "Two", "Three"], ["Three", "Four", "Five"]]
 
                 beforeEach() {
-                    self.unitUnderTest = TableViewDataSource(objects: objects, cellReuseId: self.reuseId)
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cellNib: nil)
                 }
 
                 it("Should set the objects array") {
@@ -45,12 +45,20 @@ class TableViewDataSourceSpec: QuickSpec {
 
                 it("Should set the objects array to an empty array if the parameter is nil") {
                     let objects: [[String]]? = nil
-                    self.unitUnderTest = TableViewDataSource(objects: objects, cellReuseId: self.reuseId)
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cellNib: nil)
                     expect(self.unitUnderTest.objects.count).to(equal(0))
                 }
 
-                it("Should set the reuse id") {
-                    expect(self.unitUnderTest.reuseId).to(equal(self.reuseId))
+                it("Should set the cellNib if provided") {
+                    let nib = UINib()
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cell: nib)
+                    expect(self.unitUnderTest.cellNib).to(be(nib))
+                }
+
+                it("Should set the cellClass if provided") {
+                    let cellClass = UITableViewCell.self
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cell: cellClass)
+                    expect(self.unitUnderTest.cellClass).to(be(cellClass))
                 }
             }
 
@@ -58,7 +66,7 @@ class TableViewDataSourceSpec: QuickSpec {
                 let objects = [["S0R0", "S0R1", "S0R2"], ["S1R0", "S1R1", "S1R2"]]
 
                 beforeEach {
-                    self.unitUnderTest = TableViewDataSource(objects: objects, cellReuseId: self.reuseId)
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cellNib: nil)
                 }
 
                 it("Should delete the object at the specified index path") {
@@ -73,7 +81,7 @@ class TableViewDataSourceSpec: QuickSpec {
                 let objects = [["S0R0", "S0R1", "S0R2"], ["S1R0", "S1R1", "S1R2"]]
 
                 beforeEach {
-                    self.unitUnderTest = TableViewDataSource(objects: objects, cellReuseId: self.reuseId)
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cellNib: nil)
                 }
 
                 it("Should insert the given object at the specified index path") {
@@ -89,7 +97,7 @@ class TableViewDataSourceSpec: QuickSpec {
                 let objects = [["S0R0", "S0R1", "S0R2"], ["S1R0", "S1R1", "S1R2"]]
 
                 beforeEach {
-                    self.unitUnderTest = TableViewDataSource(objects: objects, cellReuseId: self.reuseId)
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cellNib: nil)
                 }
 
                 it("Should move the object at the from index path to the to index path") {
@@ -108,7 +116,7 @@ class TableViewDataSourceSpec: QuickSpec {
                 let objects = [["S0R0", "S0R1", "S0R2"], ["S1R0", "S1R1", "S1R2"]]
 
                 beforeEach {
-                    self.unitUnderTest = TableViewDataSource(objects: objects, cellReuseId: self.reuseId)
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cellNib: nil)
                 }
 
                 it("Should return the object at the specified index path") {
@@ -122,7 +130,7 @@ class TableViewDataSourceSpec: QuickSpec {
                 let objects = [["S0R0", "S0R1", "S0R2"], ["S1R0", "S1R1", "S1R2"]]
 
                 beforeEach {
-                    self.unitUnderTest = TableViewDataSource(objects: objects, cellReuseId: self.reuseId)
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cellNib: nil)
                 }
 
                 it("Should return 2 if there is no delegate set") {
@@ -139,7 +147,7 @@ class TableViewDataSourceSpec: QuickSpec {
 
             context("sectionIndexTitles(for:)") {
                 beforeEach {
-                    self.unitUnderTest = TableViewDataSource(objects: [""], cellReuseId: self.reuseId)
+                    self.unitUnderTest = TableViewDataSource(objects: [""])
                 }
 
                 it("should return the value from the delegate if the delegate provides one.") {
@@ -160,7 +168,7 @@ class TableViewDataSourceSpec: QuickSpec {
                 let objects = [["S0R0", "S0R1", "S0R2"], ["S1R0", "S1R1"]]
 
                 beforeEach {
-                    self.unitUnderTest = TableViewDataSource(objects: objects, cellReuseId: self.reuseId)
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cellNib: nil)
                 }
 
                 it("Should return 2 if there is no delegate set.") {
@@ -185,7 +193,7 @@ class TableViewDataSourceSpec: QuickSpec {
                     indexPath = IndexPath(row: 0, section: 0)
                     tableView = UITableView()
                     delegate = MockTableViewDataSourceDelegate()
-                    self.unitUnderTest = TableViewDataSource(objects: objects, cellReuseId: self.reuseId)
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cellNib: nil)
                 }
                 
                 it("should call the delegate if one is set") {
@@ -214,7 +222,7 @@ class TableViewDataSourceSpec: QuickSpec {
                     indexPath = IndexPath(row: 0, section: 0)
                     tableView = UITableView()
                     delegate = MockTableViewDataSourceDelegate()
-                    self.unitUnderTest = TableViewDataSource(objects: objects, cellReuseId: self.reuseId)
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cellNib: nil)
                 }
 
                 it("should call the delegate if one is set") {
@@ -244,7 +252,8 @@ class TableViewDataSourceSpec: QuickSpec {
                     tableView = UITableView()
                     tableView.register(UITableViewCell.self, forCellReuseIdentifier: self.reuseId)
                     delegate = MockTableViewDataSourceDelegate()
-                    self.unitUnderTest = TableViewDataSource(objects: objects, cellReuseId: self.reuseId)
+                    let cellClass = UITableViewCell.self
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cellClass: cellClass)
                     tableView.dataSource = self.unitUnderTest
                 }
 
@@ -259,15 +268,15 @@ class TableViewDataSourceSpec: QuickSpec {
                     delegate.shouldReturnCell = false
                     self.unitUnderTest.delegate = delegate
 
-                    expect(self.unitUnderTest.tableView(tableView, cellForRowAt: indexPath).reuseIdentifier).to(equal(self.reuseId))
+                    expect(self.unitUnderTest.tableView(tableView, cellForRowAt: indexPath)).toNot(beNil())
                 }
 
                 it("should return a cell from the table view if the delegate is not set") {
-                    expect(self.unitUnderTest.tableView(tableView, cellForRowAt: indexPath).reuseIdentifier).to(equal(self.reuseId))
+                    expect(self.unitUnderTest.tableView(tableView, cellForRowAt: indexPath)).toNot(beNil())
                 }
 
                 it("should pass the cell to the presenter if available") {
-                    self.unitUnderTest = TableViewDataSource(objects: objects, cellReuseId: self.reuseId, cellPresenter: { (cell, object) in
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cellClass: UITableViewCell.self, cellPresenter: { (cell, object) in
                         expect(cell).toNot(beNil())
                     })
 
@@ -278,7 +287,7 @@ class TableViewDataSourceSpec: QuickSpec {
                 }
 
                 it("should pass the object to the presenter if available") {
-                    self.unitUnderTest = TableViewDataSource(objects: objects, cellReuseId: self.reuseId, cellPresenter: { (cell, object) in
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cellClass: UITableViewCell.self, cellPresenter: { (cell, object) in
                         expect(object).to(equal("S0R0"))
                     })
 
@@ -300,7 +309,7 @@ class TableViewDataSourceSpec: QuickSpec {
                     tableView = UITableView()
                     tableView.register(UITableViewCell.self, forCellReuseIdentifier: self.reuseId)
                     delegate = MockTableViewDataSourceDelegate()
-                    self.unitUnderTest = TableViewDataSource(objects: objects, cellReuseId: self.reuseId)
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cellNib: nil)
                     tableView.dataSource = self.unitUnderTest
                     self.unitUnderTest.delegate = delegate
                 }
@@ -322,7 +331,7 @@ class TableViewDataSourceSpec: QuickSpec {
                     tableView = UITableView()
                     tableView.register(UITableViewCell.self, forCellReuseIdentifier: self.reuseId)
                     delegate = MockTableViewDataSourceDelegate()
-                    self.unitUnderTest = TableViewDataSource(objects: objects, cellReuseId: self.reuseId)
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cellNib: nil)
                     tableView.dataSource = self.unitUnderTest
                     self.unitUnderTest.delegate = delegate
                 }
@@ -335,7 +344,7 @@ class TableViewDataSourceSpec: QuickSpec {
 
             context("tableView(_:sectionForSectionIndexTitle:index:)") {
                 beforeEach {
-                    self.unitUnderTest = TableViewDataSource(objects: [""], cellReuseId: self.reuseId)
+                    self.unitUnderTest = TableViewDataSource(objects: [""])
                 }
 
                 it("should return the delegate value if there is a delegate") {
@@ -360,7 +369,7 @@ class TableViewDataSourceSpec: QuickSpec {
                     tableView = UITableView()
                     tableView.register(UITableViewCell.self, forCellReuseIdentifier: self.reuseId)
                     delegate = MockTableViewDataSourceDelegate()
-                    self.unitUnderTest = TableViewDataSource(objects: objects, cellReuseId: self.reuseId)
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cellNib: nil)
                     tableView.dataSource = self.unitUnderTest
                     self.unitUnderTest.footerTitles = footers
                 }
@@ -400,7 +409,7 @@ class TableViewDataSourceSpec: QuickSpec {
                     tableView = UITableView()
                     tableView.register(UITableViewCell.self, forCellReuseIdentifier: self.reuseId)
                     delegate = MockTableViewDataSourceDelegate()
-                    self.unitUnderTest = TableViewDataSource(objects: objects, cellReuseId: self.reuseId)
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cellNib: nil)
                     tableView.dataSource = self.unitUnderTest
                     self.unitUnderTest.headerTitles = headers
                 }

--- a/Tests/TableViewDataSourceSpec.swift
+++ b/Tests/TableViewDataSourceSpec.swift
@@ -19,23 +19,142 @@ class TableViewDataSourceSpec: QuickSpec {
 
     override func spec() {
         describe("TableViewDataSource") {
-            context("init(objects:cellReuseId:)") {
-                let objects = ["One", "Two", "Three"]
 
-                beforeEach() {
-                    self.unitUnderTest = TableViewDataSource(objects: objects, delegate: MockTableViewDataSourceDelegate())
+            // MARK: Initializers
+
+            context("init(objects:cellPresenter:delegate:)") {
+                var delegate: TableViewDataSourceDelegate!
+                var objects: [String]!
+
+                beforeEach {
+                    delegate = MockTableViewDataSourceDelegate()
+                    objects = ["One", "Two", "Three", "Four", "Five"]
+                    self.unitUnderTest = TableViewDataSource(objects: objects, delegate: delegate)
                 }
 
-                it("Should wrap the objects array in an array and set to objects") {
+                it("Should wrap the objects array") {
                     expect(self.unitUnderTest.objects.first).to(equal(objects))
+                }
+
+                it("Should set the delegate") {
+                    expect(self.unitUnderTest.delegate).to(be(delegate))
                 }
             }
 
-            context("init(objects:cellReuseId:)") {
+            context("init(objects:cellPresenter:delegate:)") {
+                var delegate: TableViewDataSourceDelegate!
+                var objects: [[String]]!
+
+                beforeEach {
+                    delegate = MockTableViewDataSourceDelegate()
+                    objects = [["One", "Two", "Three"], ["Three", "Four", "Five"]]
+                    self.unitUnderTest = TableViewDataSource(objects: objects, delegate: delegate)
+                }
+
+                it("Should set the delegate") {
+                    expect(self.unitUnderTest.delegate).to(be(delegate))
+                }
+            }
+
+            context("init(objects:cell:cellPresenter:)") {
+                var nib: UINib!
+                var objects: [String]!
+
+                beforeEach {
+                    nib = UINib()
+                    objects = ["One", "Two", "Three", "Four", "Five"]
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cell: nib)
+                }
+
+                it("Should wrap the objects array") {
+                    expect(self.unitUnderTest.objects.first).to(equal(objects))
+                }
+
+                it("Should set the cellNib") {
+                    expect(self.unitUnderTest.cellNib).to(be(nib))
+                }
+
+                it("Should set the cellClass to nil") {
+                    expect(self.unitUnderTest.cellClass).to(beNil())
+                }
+            }
+
+            context("init(objects:cell:cellPresenter:)") {
+                var nib: UINib!
+                var objects: [[String]]!
+
+                beforeEach {
+                    nib = UINib()
+                    objects = [["One", "Two", "Three"], ["Three", "Four", "Five"]]
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cell: nib)
+                }
+
+                it("Should set the cellNib") {
+                    expect(self.unitUnderTest.cellNib).to(be(nib))
+                }
+
+                it("Should set the cellClass to nil") {
+                    expect(self.unitUnderTest.cellClass).to(beNil())
+                }
+            }
+
+            context("init(objects:cell:cellPresenter:)") {
+                var cellClass: UITableViewCell.Type!
+                var objects: [String]!
+
+                beforeEach {
+                    cellClass = UITableViewCell.self
+                    objects = ["One", "Two", "Three", "Four", "Five"]
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cell: cellClass)
+                }
+
+                it("Should wrap the objects array") {
+                    let cellClass = UITableViewCell.self
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cell: cellClass)
+                    expect(self.unitUnderTest.objects.first).to(equal(objects))
+                }
+
+                it("Should set the cellClass") {
+                    let cellClass = UITableViewCell.self
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cell: cellClass)
+                    expect(self.unitUnderTest.cellClass).to(be(cellClass))
+                }
+
+                it("Should set the cellNib to nil") {
+                    let cellClass = UITableViewCell.self
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cell: cellClass)
+                    expect(self.unitUnderTest.cellNib).to(beNil())
+                }
+            }
+
+            context("init(objects:cell:cellPresenter:)") {
+                var cellClass: UITableViewCell.Type!
+                var objects: [[String]]!
+
+                beforeEach {
+                    cellClass = UITableViewCell.self
+                    objects = [["One", "Two", "Three"], ["Three", "Four", "Five"]]
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cell: cellClass)
+                }
+
+                it("Should set the cellClass") {
+                    let cellClass = UITableViewCell.self
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cell: cellClass)
+                    expect(self.unitUnderTest.cellClass).to(be(cellClass))
+                }
+
+                it("Should set the cellNib to nil") {
+                    let cellClass = UITableViewCell.self
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cell: cellClass)
+                    expect(self.unitUnderTest.cellNib).to(beNil())
+                }
+            }
+
+            context("init(objects:cellClass:cellNib:cellPresenter:)") {
                 let objects: [[String]] = [["One", "Two", "Three"], ["Three", "Four", "Five"]]
 
                 beforeEach() {
-                    self.unitUnderTest = TableViewDataSource(objects: objects, cellNib: nil)
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cellClass: nil, cellNib: nil, cellPresenter: nil)
                 }
 
                 it("Should set the objects array") {
@@ -45,22 +164,12 @@ class TableViewDataSourceSpec: QuickSpec {
 
                 it("Should set the objects array to an empty array if the parameter is nil") {
                     let objects: [[String]]? = nil
-                    self.unitUnderTest = TableViewDataSource(objects: objects, cellNib: nil)
+                    self.unitUnderTest = TableViewDataSource(objects: objects, cellClass: nil, cellNib: nil, cellPresenter: nil)
                     expect(self.unitUnderTest.objects.count).to(equal(0))
                 }
-
-                it("Should set the cellNib if provided") {
-                    let nib = UINib()
-                    self.unitUnderTest = TableViewDataSource(objects: objects, cell: nib)
-                    expect(self.unitUnderTest.cellNib).to(be(nib))
-                }
-
-                it("Should set the cellClass if provided") {
-                    let cellClass = UITableViewCell.self
-                    self.unitUnderTest = TableViewDataSource(objects: objects, cell: cellClass)
-                    expect(self.unitUnderTest.cellClass).to(be(cellClass))
-                }
             }
+
+            // MARK: Public Methods
 
             context("delete(indexPath:)") {
                 let objects = [["S0R0", "S0R1", "S0R2"], ["S1R0", "S1R1", "S1R2"]]
@@ -147,7 +256,7 @@ class TableViewDataSourceSpec: QuickSpec {
 
             context("sectionIndexTitles(for:)") {
                 beforeEach {
-                    self.unitUnderTest = TableViewDataSource(objects: [""], delegate: MockTableViewDataSourceDelegate())
+                    self.unitUnderTest = TableViewDataSource(objects: [[""]], cellNib: nil)
                 }
 
                 it("should return the value from the delegate if the delegate provides one.") {
@@ -163,6 +272,64 @@ class TableViewDataSourceSpec: QuickSpec {
                     expect(self.unitUnderTest.sectionIndexTitles(for: UITableView())).to(beNil())
                 }
             }
+
+            // MARK: Internal Methods
+
+            context("registerCellIfNeeded(tableView:)") {
+                var tableView: MockTableView!
+
+                beforeEach {
+                    tableView = MockTableView()
+                    self.unitUnderTest = TableViewDataSource(objects: [[String]](), cellClass: nil, cellNib: nil, cellPresenter: nil)
+                }
+
+                it("Should return the reuseId if one has already been set") {
+                    self.unitUnderTest.reuseId = "TestReuseId"
+                    let result = self.unitUnderTest.registerCellIfNeeded(tableView: tableView)
+                    expect(result).to(equal("TestReuseId"))
+                }
+
+                it("Should not call the register methods if a reuse id is already set") {
+                    self.unitUnderTest.reuseId = "TestReuseId"
+                    let _ = self.unitUnderTest.registerCellIfNeeded(tableView: tableView)
+                    expect(tableView.registerClassCaled).to(beFalse())
+                    expect(tableView.registerNibCalled).to(beFalse())
+                }
+
+                it("Should call register nib if a nib is provided in the init") {
+                    self.unitUnderTest = TableViewDataSource(objects: [[String]](), cellClass: nil, cellNib: UINib(), cellPresenter: nil)
+                    let _ = self.unitUnderTest.registerCellIfNeeded(tableView: tableView)
+                    expect(tableView.registerClassCaled).to(beFalse())
+                    expect(tableView.registerNibCalled).to(beTrue())
+                }
+
+                it("Should call register class if a class is provided in the init") {
+                    self.unitUnderTest = TableViewDataSource(objects: [[String]](), cellClass: UITableViewCell.self, cellNib: nil, cellPresenter: nil)
+                    let _ = self.unitUnderTest.registerCellIfNeeded(tableView: tableView)
+                    expect(tableView.registerClassCaled).to(beTrue())
+                }
+
+                it("Should raise an exception") {
+                    self.unitUnderTest = TableViewDataSource(objects: [[String]](), cellClass: nil, cellNib: nil, cellPresenter: nil)
+                    expect(self.unitUnderTest.registerCellIfNeeded(tableView: tableView)).to(raiseException())
+                }
+            }
+
+            context("wrapObjects(_:)") {
+                it("Should wrap the input array in an array") {
+                    let inputArray = ["One", "Two", "Three", "Four"]
+                    let result = TableViewDataSource.wrapObjects(inputArray)
+                    expect(result.first).to(equal(inputArray))
+                }
+
+                it("Should return an empty array if nil is passed in as the input array") {
+                    let inputArray: [String]? = nil
+                    let result = TableViewDataSource.wrapObjects(inputArray)
+                    expect(result).to(beAnInstanceOf(Array<Array<String>>.self))
+                }
+            }
+
+            // MARK: UITableViewDataSource Methods
 
             context("tableView(_:numberOfRowsInSection:)") {
                 let objects = [["S0R0", "S0R1", "S0R2"], ["S1R0", "S1R1"]]
@@ -344,7 +511,7 @@ class TableViewDataSourceSpec: QuickSpec {
 
             context("tableView(_:sectionForSectionIndexTitle:index:)") {
                 beforeEach {
-                    self.unitUnderTest = TableViewDataSource(objects: [""], delegate: MockTableViewDataSourceDelegate())
+                    self.unitUnderTest = TableViewDataSource(objects: [[""]], cellNib: nil)
                 }
 
                 it("should return the delegate value if there is a delegate") {

--- a/Tests/TableViewDataSourceSpec.swift
+++ b/Tests/TableViewDataSourceSpec.swift
@@ -23,7 +23,7 @@ class TableViewDataSourceSpec: QuickSpec {
                 let objects = ["One", "Two", "Three"]
 
                 beforeEach() {
-                    self.unitUnderTest = TableViewDataSource(objects: objects)
+                    self.unitUnderTest = TableViewDataSource(objects: objects, delegate: MockTableViewDataSourceDelegate())
                 }
 
                 it("Should wrap the objects array in an array and set to objects") {
@@ -147,7 +147,7 @@ class TableViewDataSourceSpec: QuickSpec {
 
             context("sectionIndexTitles(for:)") {
                 beforeEach {
-                    self.unitUnderTest = TableViewDataSource(objects: [""])
+                    self.unitUnderTest = TableViewDataSource(objects: [""], delegate: MockTableViewDataSourceDelegate())
                 }
 
                 it("should return the value from the delegate if the delegate provides one.") {
@@ -344,7 +344,7 @@ class TableViewDataSourceSpec: QuickSpec {
 
             context("tableView(_:sectionForSectionIndexTitle:index:)") {
                 beforeEach {
-                    self.unitUnderTest = TableViewDataSource(objects: [""])
+                    self.unitUnderTest = TableViewDataSource(objects: [""], delegate: MockTableViewDataSourceDelegate())
                 }
 
                 it("should return the delegate value if there is a delegate") {


### PR DESCRIPTION
Reworked cell registration and data source initialization. A nib or cell type is passed instead of the cellReuseId. This nib or cell type is registered with the table view when appropriate. If this behavior is not wanted, the `init(objects:delegate:cellPresenter:)` methods can be used. The delegate must handle cell registration and cellForRowAtIndexPath for all cells.